### PR TITLE
[BACKEND] Pages Collection Using Block-Based Layout Builder

### DIFF
--- a/src/app/(frontend)/about-us/page.tsx
+++ b/src/app/(frontend)/about-us/page.tsx
@@ -1,11 +1,28 @@
+import React from 'react'
 import AboutIntro from '../components/AboutIntro'
 import Grid from '../components/Grid'
 import Hero from '../components/Hero'
 
-export default function AboutUsPage() {
+import { getPageBySlug } from '@/lib/getPageBySlug'
+import type { Media } from '@/payload-types'
+
+export default async function AboutUsPage() {
+  const page = await getPageBySlug('about-us')
+
+  const heroBlock = page?.layout?.find((block) => block.blockType === 'hero')
+
+  const heroTitle = heroBlock?.title || 'About Us'
+
+  const heroImage = heroBlock?.backgroundImage
+
+  const heroImageUrl =
+    typeof heroImage === 'object' && heroImage !== null
+      ? (heroImage as Media).url
+      : '/hero-placeholder.jpg'
+
   return (
     <div>
-      <Hero title="About Us" backgroundImage="/hero-placeholder.jpg" />
+      <Hero title={heroTitle} backgroundImage={heroImageUrl ?? '/hero-placeholder.jpg'} />
       <main className="min-h-screen bg-white text-black">
         <AboutIntro />
         <Grid title="People" placeholderSubtitle="Name" />

--- a/src/app/(frontend)/concerts-events/page.tsx
+++ b/src/app/(frontend)/concerts-events/page.tsx
@@ -1,9 +1,27 @@
+import React from 'react'
 import Hero from '../components/Hero'
-export default function ConcertsEventsPage() {
+
+import { getPageBySlug } from '@/lib/getPageBySlug'
+import type { Media } from '@/payload-types'
+
+export default async function ConcertsEventsPage() {
+  const page = await getPageBySlug('concerts-events')
+
+  const heroBlock = page?.layout?.find((block) => block.blockType === 'hero')
+
+  const heroTitle = heroBlock?.title || 'Concerts & Events'
+
+  const heroImage = heroBlock?.backgroundImage
+
+  const heroImageUrl =
+    typeof heroImage === 'object' && heroImage !== null
+      ? (heroImage as Media).url
+      : '/hero-placeholder.jpg'
+
   return (
     <div className="w-full h-[400px] relative">
       <div className="w-full h-[vh] relative">
-        <Hero title="Concert & Events" backgroundImage="/hero-placeholder.jpg" />
+        <Hero title={heroTitle} backgroundImage={heroImageUrl ?? '/hero-placeholder.jpg'} />
       </div>
       <main>This is the concerts & events page</main>
     </div>

--- a/src/app/(frontend)/join-ayo/page.tsx
+++ b/src/app/(frontend)/join-ayo/page.tsx
@@ -1,12 +1,29 @@
+import React from 'react'
 import FAQSection from '../components/FAQSection'
 import OpportunitySection from '../components/OpportunitySection'
 import OpportunityModal from '../components/OpportunityModal'
 import Hero from '../components/Hero'
 
-export default function JoinAyoPage() {
+import { getPageBySlug } from '@/lib/getPageBySlug'
+import type { Media } from '@/payload-types'
+
+export default async function JoinAyoPage() {
+  const page = await getPageBySlug('join-ayo')
+
+  const heroBlock = page?.layout?.find((block) => block.blockType === 'hero')
+
+  const heroTitle = heroBlock?.title || 'Join AYO'
+
+  const heroImage = heroBlock?.backgroundImage
+
+  const heroImageUrl =
+    typeof heroImage === 'object' && heroImage !== null
+      ? (heroImage as Media).url
+      : '/hero-placeholder.jpg'
+
   return (
     <main>
-      <Hero title="Join AYO" backgroundImage="/hero-placeholder.jpg" />
+      <Hero title={heroTitle} backgroundImage={heroImageUrl ?? '/hero-placeholder.jpg'} />
       <OpportunitySection />
       <FAQSection />
     </main>

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -4,10 +4,26 @@ import AboutIntro from './components/AboutIntro'
 import EventsBlock from './components/events/EventsBlock'
 import BlogsBlock from './components/blogs/BlogsBlock'
 
-export default function LandingPage() {
+import { getPageBySlug } from '@/lib/getPageBySlug'
+import type { Media } from '@/payload-types'
+
+export default async function LandingPage() {
+  const page = await getPageBySlug('home')
+
+  const heroBlock = page?.layout?.find((block) => block.blockType === 'hero')
+
+  const heroTitle = heroBlock?.title || 'Here Plays The Future'
+
+  const heroImage = heroBlock?.backgroundImage
+
+  const heroImageUrl =
+    typeof heroImage === 'object' && heroImage !== null
+      ? (heroImage as Media).url
+      : '/hero-placeholder.jpg'
+
   return (
     <main className="min-h-screen bg-white text-black">
-      <Hero title="Here Plays The Future" backgroundImage="/hero-placeholder.jpg" />
+      <Hero title={heroTitle} backgroundImage={heroImageUrl ?? '/hero-placeholder.jpg'} />
       <AboutIntro />
       <EventsBlock />
       <BlogsBlock />

--- a/src/app/(frontend)/support-us/page.tsx
+++ b/src/app/(frontend)/support-us/page.tsx
@@ -1,7 +1,25 @@
+import React from 'react'
 import Link from 'next/link'
 import DonationBlock from '../components/DonationBlock'
 import Hero from '../components/Hero'
-export default function SupportUsPage() {
+
+import { getPageBySlug } from '@/lib/getPageBySlug'
+import type { Media } from '@/payload-types'
+
+export default async function SupportUsPage() {
+  const page = await getPageBySlug('support-us')
+
+  const heroBlock = page?.layout?.find((block) => block.blockType === 'hero')
+
+  const heroTitle = heroBlock?.title || 'Support Us'
+
+  const heroImage = heroBlock?.backgroundImage
+
+  const heroImageUrl =
+    typeof heroImage === 'object' && heroImage !== null
+      ? (heroImage as Media).url
+      : '/hero-placeholder.jpg'
+
   const tierArray = [
     {
       tierName: 'Subscriber',
@@ -70,7 +88,7 @@ export default function SupportUsPage() {
   return (
     <main>
       <div className="w-full h-[vh] relative">
-        <Hero title="Support Us" backgroundImage="/hero-placeholder.jpg" />
+        <Hero title={heroTitle} backgroundImage={heroImageUrl ?? '/hero-placeholder.jpg'} />
       </div>
 
       <div className="text-black w-full">

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,5 +1,51 @@
+import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
+import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
+import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
+import { InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { UploadFeatureClient as UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { BlockquoteFeatureClient as BlockquoteFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { RelationshipFeatureClient as RelationshipFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { LinkFeatureClient as LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { ChecklistFeatureClient as ChecklistFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { OrderedListFeatureClient as OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { UnorderedListFeatureClient as UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { IndentFeatureClient as IndentFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { AlignFeatureClient as AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { HeadingFeatureClient as HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { ParagraphFeatureClient as ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { InlineCodeFeatureClient as InlineCodeFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { SuperscriptFeatureClient as SuperscriptFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { SubscriptFeatureClient as SubscriptFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { StrikethroughFeatureClient as StrikethroughFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
 export const importMap = {
+  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient": InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#UploadFeatureClient": UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#BlockquoteFeatureClient": BlockquoteFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#RelationshipFeatureClient": RelationshipFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#LinkFeatureClient": LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#ChecklistFeatureClient": ChecklistFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#OrderedListFeatureClient": OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#UnorderedListFeatureClient": UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#IndentFeatureClient": IndentFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#AlignFeatureClient": AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#HeadingFeatureClient": HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#ParagraphFeatureClient": ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#InlineCodeFeatureClient": InlineCodeFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#SuperscriptFeatureClient": SuperscriptFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#SubscriptFeatureClient": SubscriptFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#StrikethroughFeatureClient": StrikethroughFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1
 }

--- a/src/blocks/CTA.ts
+++ b/src/blocks/CTA.ts
@@ -1,0 +1,26 @@
+import type { Block } from 'payload'
+
+export const CTA: Block = {
+  slug: 'cta',
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'description',
+      type: 'textarea',
+    },
+    {
+      name: 'buttonText',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'buttonLink',
+      type: 'text',
+      required: true,
+    },
+  ],
+}

--- a/src/blocks/CTA.ts
+++ b/src/blocks/CTA.ts
@@ -10,7 +10,7 @@ export const CTA: Block = {
     },
     {
       name: 'description',
-      type: 'textarea',
+      type: 'richText',
     },
     {
       name: 'buttonText',

--- a/src/blocks/CTA.ts
+++ b/src/blocks/CTA.ts
@@ -1,5 +1,15 @@
 import type { Block } from 'payload'
 
+/**
+ * Call to Action (CTA) block:
+ *
+ * Standalone prompt section with a heading, optional description,
+ * and a single button.
+ * - title: heading text
+ * - description: optional rich text supporting content
+ * - buttonText / buttonLink: label and destination for the CTA button
+ */
+
 export const CTA: Block = {
   slug: 'cta',
   fields: [

--- a/src/blocks/Gallery.ts
+++ b/src/blocks/Gallery.ts
@@ -1,0 +1,28 @@
+import type { Block } from 'payload'
+
+export const Gallery: Block = {
+  slug: 'gallery',
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+    {
+      name: 'images',
+      type: 'array',
+      required: true,
+      fields: [
+        {
+          name: 'image',
+          type: 'upload',
+          relationTo: 'media',
+          required: true,
+        },
+        {
+          name: 'caption',
+          type: 'text',
+        },
+      ],
+    },
+  ],
+}

--- a/src/blocks/Gallery.ts
+++ b/src/blocks/Gallery.ts
@@ -1,5 +1,15 @@
 import type { Block } from 'payload'
 
+/**
+ * Gallery block:
+ *
+ * Displays a set of images in a page layout.
+ * - title: optional section heading
+ * - images: repeatable array of image + caption pairs
+ *   - image: upload from Media collection
+ *   - caption: optional text shown alongside/under the image
+ */
+
 export const Gallery: Block = {
   slug: 'gallery',
   fields: [

--- a/src/blocks/Hero.ts
+++ b/src/blocks/Hero.ts
@@ -1,0 +1,18 @@
+import type { Block } from 'payload'
+
+export const Hero: Block = {
+  slug: 'hero',
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'backgroundImage',
+      type: 'upload',
+      relationTo: 'media',
+      required: true,
+    },
+  ],
+}

--- a/src/blocks/Hero.ts
+++ b/src/blocks/Hero.ts
@@ -1,5 +1,16 @@
 import type { Block } from 'payload'
 
+/**
+ * Hero block:
+ *
+ * Used at the top of a page for a large banner-style section.
+ * - title: heading text displayed over the background
+ * - backgroundImage: image from the Media collection
+ *
+ * Note: ticket calls for image/video + CTA button support; current
+ * version covers image only, no button. Deferred for future iteration.
+ */
+
 export const Hero: Block = {
   slug: 'hero',
   fields: [

--- a/src/blocks/RichText.ts
+++ b/src/blocks/RichText.ts
@@ -1,5 +1,14 @@
 import type { Block } from 'payload'
 
+/**
+ * Rich Text block:
+ *
+ * Freeform text section for page content.
+ * - title: optional heading above the text content
+ * - content: Lexical rich text field (stores structured JSON, rendered
+ *   on the frontend via @payloadcms/richtext-lexical/react)
+ */
+
 export const RichText: Block = {
   slug: 'rich-text',
   fields: [

--- a/src/blocks/RichText.ts
+++ b/src/blocks/RichText.ts
@@ -1,0 +1,16 @@
+import type { Block } from 'payload'
+
+export const RichText: Block = {
+  slug: 'rich-text',
+  fields: [
+    {
+      name: 'heading',
+      type: 'text',
+    },
+    {
+      name: 'content',
+      type: 'richText',
+      required: true,
+    },
+  ],
+}

--- a/src/blocks/RichText.ts
+++ b/src/blocks/RichText.ts
@@ -4,7 +4,7 @@ export const RichText: Block = {
   slug: 'rich-text',
   fields: [
     {
-      name: 'heading',
+      name: 'title',
       type: 'text',
     },
     {

--- a/src/blocks/Spacer.ts
+++ b/src/blocks/Spacer.ts
@@ -1,0 +1,26 @@
+import type { Block } from 'payload'
+
+export const Spacer: Block = {
+  slug: 'spacer',
+  fields: [
+    {
+      name: 'height',
+      type: 'select',
+      required: true,
+      options: [
+        {
+          label: 'Small',
+          value: 'small',
+        },
+        {
+          label: 'Medium',
+          value: 'medium',
+        },
+        {
+          label: 'Large',
+          value: 'large',
+        },
+      ],
+    },
+  ],
+}

--- a/src/blocks/Spacer.ts
+++ b/src/blocks/Spacer.ts
@@ -1,5 +1,13 @@
 import type { Block } from 'payload'
 
+/**
+ * Spacer block:
+ *
+ * Adds vertical whitespace between other blocks in a layout.
+ * - height: preset spacing size (small/medium/large) rather than a
+ *   free-form value, to keep spacing consistent across pages
+ */
+
 export const Spacer: Block = {
   slug: 'spacer',
   fields: [

--- a/src/collections/Pages.ts
+++ b/src/collections/Pages.ts
@@ -1,0 +1,30 @@
+import type { CollectionConfig } from 'payload'
+import { Hero } from '@/blocks/Hero'
+import { RichText } from '@/blocks/RichText'
+import { Spacer } from '@/blocks/Spacer'
+import { CTA } from '@/blocks/CTA'
+import { Gallery } from '@/blocks/Gallery'
+
+export const Pages: CollectionConfig = {
+  slug: 'pages',
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'slug',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'layout',
+      type: 'blocks',
+      blocks: [Hero, RichText, Gallery, Spacer, CTA],
+    },
+  ],
+}

--- a/src/collections/Pages.ts
+++ b/src/collections/Pages.ts
@@ -5,6 +5,20 @@ import { Spacer } from '@/blocks/Spacer'
 import { CTA } from '@/blocks/CTA'
 import { Gallery } from '@/blocks/Gallery'
 
+/**
+ * Pages collection:
+ *
+ * Block-based page builder for static/public-facing pages
+ * (Home, About, Get Involved, Support Us, Contact, etc).
+ *
+ * - title: internal admin-facing page name
+ * - slug: URL identifier used by the frontend to resolve which page
+ *   to render (e.g. "home", "about", "support-us")
+ * - layout: ordered array of content blocks (Hero, RichText, Gallery,
+ *   Spacer, CTA) that the admin composes per page without needing a
+ *   developer to hardcode frontend content
+ */
+
 export const Pages: CollectionConfig = {
   slug: 'pages',
   admin: {

--- a/src/lib/getPageBySlug.ts
+++ b/src/lib/getPageBySlug.ts
@@ -1,0 +1,24 @@
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import type { Page } from '@/payload-types'
+
+export async function getPageBySlug(slug: string): Promise<Page | null> {
+  try {
+    const payload = await getPayload({ config })
+
+    const { docs } = await payload.find({
+      collection: 'pages',
+      where: {
+        slug: {
+          equals: slug,
+        },
+      },
+      limit: 1,
+    })
+
+    return docs[0] || null
+  } catch (error) {
+    console.error('Error fetching page by slug:', error)
+    return null
+  }
+}

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -70,6 +70,7 @@ export interface Config {
     users: User;
     media: Media;
     partners: Partner;
+    pages: Page;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -80,6 +81,7 @@ export interface Config {
     users: UsersSelect<false> | UsersSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
     partners: PartnersSelect<false> | PartnersSelect<true>;
+    pages: PagesSelect<false> | PagesSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -179,6 +181,89 @@ export interface Partner {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "pages".
+ */
+export interface Page {
+  id: string;
+  title: string;
+  slug: string;
+  layout?:
+    | (
+        | {
+            title: string;
+            backgroundImage: string | Media;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'hero';
+          }
+        | {
+            title?: string | null;
+            content: {
+              root: {
+                type: string;
+                children: {
+                  type: any;
+                  version: number;
+                  [k: string]: unknown;
+                }[];
+                direction: ('ltr' | 'rtl') | null;
+                format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+                indent: number;
+                version: number;
+              };
+              [k: string]: unknown;
+            };
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'rich-text';
+          }
+        | {
+            title?: string | null;
+            images: {
+              image: string | Media;
+              caption?: string | null;
+              id?: string | null;
+            }[];
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'gallery';
+          }
+        | {
+            height: 'small' | 'medium' | 'large';
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'spacer';
+          }
+        | {
+            title: string;
+            description?: {
+              root: {
+                type: string;
+                children: {
+                  type: any;
+                  version: number;
+                  [k: string]: unknown;
+                }[];
+                direction: ('ltr' | 'rtl') | null;
+                format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+                indent: number;
+                version: number;
+              };
+              [k: string]: unknown;
+            } | null;
+            buttonText: string;
+            buttonLink: string;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'cta';
+          }
+      )[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -212,6 +297,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'partners';
         value: string | Partner;
+      } | null)
+    | ({
+        relationTo: 'pages';
+        value: string | Page;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -305,6 +394,67 @@ export interface PartnersSelect<T extends boolean = true> {
   logo?: T;
   websiteUrl?: T;
   isActive?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "pages_select".
+ */
+export interface PagesSelect<T extends boolean = true> {
+  title?: T;
+  slug?: T;
+  layout?:
+    | T
+    | {
+        hero?:
+          | T
+          | {
+              title?: T;
+              backgroundImage?: T;
+              id?: T;
+              blockName?: T;
+            };
+        'rich-text'?:
+          | T
+          | {
+              title?: T;
+              content?: T;
+              id?: T;
+              blockName?: T;
+            };
+        gallery?:
+          | T
+          | {
+              title?: T;
+              images?:
+                | T
+                | {
+                    image?: T;
+                    caption?: T;
+                    id?: T;
+                  };
+              id?: T;
+              blockName?: T;
+            };
+        spacer?:
+          | T
+          | {
+              height?: T;
+              id?: T;
+              blockName?: T;
+            };
+        cta?:
+          | T
+          | {
+              title?: T;
+              description?: T;
+              buttonText?: T;
+              buttonLink?: T;
+              id?: T;
+              blockName?: T;
+            };
+      };
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -8,6 +8,7 @@ import sharp from 'sharp'
 import { Users } from './collections/Users'
 import { Media } from './collections/Media'
 import { Partners } from './collections/Partners'
+import { Pages } from './collections/Pages'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -19,7 +20,7 @@ export default buildConfig({
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Users, Media, Partners],
+  collections: [Users, Media, Partners, Pages],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || '',
   typescript: {


### PR DESCRIPTION
## Summary
Adds a `Pages` collection using Payload's Blocks field, allowing the admin to build page layouts from reusable components and replace hardcoded static page content (Home, About, Get Involved, Support Us, Contact etc.)

## Schema
`Pages` collection:
- `title` (text, required) - internal page name
- `slug` (text, required) - URL identifier used by the frontend
- `layout` (blocks) - ordered, admin-editable array of content blocks
<img width="1470" height="206" alt="Screenshot 2026-07-06 at 11 55 23 AM" src="https://github.com/user-attachments/assets/917e8f55-462d-429d-a485-066d2658004d" />
<img width="1470" height="312" alt="Screenshot 2026-07-06 at 11 55 27 AM" src="https://github.com/user-attachments/assets/cf08f4f9-16c7-4c08-b952-6e0ded8022a6" />
<img width="1470" height="499" alt="Screenshot 2026-07-06 at 11 55 32 AM" src="https://github.com/user-attachments/assets/7c618904-d854-4f06-938c-33ffb23b0957" />
<img width="1395" height="369" alt="Screenshot 2026-07-06 at 11 55 36 AM" src="https://github.com/user-attachments/assets/5bc5cc3f-3061-4592-b58e-fd8de6bd56f2" />

`Block` types implemented:
- `Hero` - title + background image
- `Rich Text` - optional title + Lexical rich text content
- `Gallery` - optional title + repeatable image/caption array
- `Spacer` - preset height (small/medium/large)
- `CTA` - title + optional rich text description + button text/link

<img width="1131" height="315" alt="Screenshot 2026-07-06 at 11 55 49 AM" src="https://github.com/user-attachments/assets/90138624-fd72-49c0-a01f-033bb69927c9" />
<img width="1101" height="259" alt="Screenshot 2026-07-06 at 11 56 00 AM" src="https://github.com/user-attachments/assets/feeb6b1e-6460-4f30-804e-b76f6cdae2ac" />
<img width="1100" height="243" alt="Screenshot 2026-07-06 at 11 56 07 AM" src="https://github.com/user-attachments/assets/024bc67a-b7c2-4190-a7da-5f782d388202" />
<img width="1108" height="172" alt="Screenshot 2026-07-06 at 11 56 13 AM" src="https://github.com/user-attachments/assets/19559e57-132f-472d-979f-9cec957337d1" />
<img width="1112" height="441" alt="Screenshot 2026-07-06 at 11 56 21 AM" src="https://github.com/user-attachments/assets/5ea14b1c-f0ce-4e78-8ab0-a2608a6182d2" />

## Testing
- Ran `pnpm dev`, logged into `/admin`
- Created a test page, added Hero, Rich Text, Gallery, Spacer, and CTA blocks to the `layout` field
- Confirmed all blocks render fields correctly and save/reload with content intact
- Ran `pnpm generate:types` to regenerate `payload-types.ts` after schema changes

## Notes
- Hero block currently supports image only, no video, and no CTA button field
- Comments are left on all block types and the pages collection
- Issues with the richText block rendering "Content" field were resolved after regenerating importMap.js, which has been committed 
- Closes #77 